### PR TITLE
Update for NVDA 2022.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2021.1",
+	"addon_lastTestedNVDAVersion": "2022.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
This Pr marks VirtualCopy as compatible with NVDA 2022.1 @tspivey  Have you considered  adding this add-on to the official web site at some point?