### PR TITLE
Add trimmed copy and block copy features

### DIFF
--- a/addon/globalPlugins/virtualCopy/__init__.py
+++ b/addon/globalPlugins/virtualCopy/__init__.py
@@ -11,6 +11,9 @@ import addonHandler
 
 addonHandler.initTranslation()
 
+def _trim_lines(text):
+	return "\r\n".join(line.strip() for line in text.splitlines())
+
 def finally_(func, final):
 	"""Calls final after func, even if it fails."""
 	def wrap(f):
@@ -34,9 +37,18 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		for c in "klw":
 			self.__toggle_gestures["KB:%s" % c] = "toggleX"
 			self.__toggle_gestures["KB:NVDA+%s" % c] = "toggleX"
+			self.__toggle_gestures["KB:shift+%s" % c] = "toggleX"
+			self.__toggle_gestures["KB:NVDA+shift+%s" % c] = "toggleX"
 		#home and end
 		self.__toggle_gestures["KB:home"] = "copy_to_start"
 		self.__toggle_gestures["KB:end"] = "copy_to_end"
+		self.__toggle_gestures["KB:shift+home"] = "copy_to_start_trimmed"
+		self.__toggle_gestures["KB:shift+end"] = "copy_to_end_trimmed"
+		#block copy
+		self.__toggle_gestures["KB:b"] = "copy_block"
+		self.__toggle_gestures["KB:NVDA+b"] = "copy_block"
+		self.__toggle_gestures["KB:shift+b"] = "copy_block_trimmed"
+		self.__toggle_gestures["KB:NVDA+shift+b"] = "copy_block_trimmed"
 
 	def getScript(self, gesture):
 		if not self.toggling:
@@ -55,46 +67,89 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def script_toggleX(self, gesture):
 		char = gesture.mainKeyName[-1]
+		trimmed = "shift" in gesture.modifierNames
 		if char == 'l':
-			self.copy_line()
+			self.copy_line(trimmed)
 		elif char == 'k':
-			self.copy_word()
+			self.copy_word(trimmed)
 		elif char == 'w':
-			self.copy_window()
+			self.copy_window(trimmed)
 		tones.beep(700, 100)
 
-	def copy_line(self):
+	def copy_line(self, trimmed=False):
 		info = api.getReviewPosition().copy()
 		info.expand(textInfos.UNIT_LINE)
-		info.copyToClipboard()
+		if trimmed:
+			api.copyToClip(_trim_lines(info.clipboardText))
+		else:
+			info.copyToClipboard()
 
-	def copy_word(self):
-		ui.message("word")
+	def copy_word(self, trimmed=False):
 		info = api.getReviewPosition().copy()
 		info.expand(textInfos.UNIT_WORD)
-		info.copyToClipboard()
+		if trimmed:
+			api.copyToClip(_trim_lines(info.clipboardText))
+		else:
+			info.copyToClipboard()
 
-	def copy_window(self):
+	def copy_window(self, trimmed=False):
 		info = api.getReviewPosition().copy()
 		info.expand(textInfos.UNIT_STORY)
 		t = info.clipboardText.rstrip('\n')
+		if trimmed:
+			t = _trim_lines(t)
 		api.copyToClip(t)
 
-	def script_copy_to_start(self, gesture):
+	def script_copy_to_start(self, gesture, trimmed=False):
 		info = api.getReviewPosition().copy()
 		info2 = info.copy()
 		info.expand(textInfos.UNIT_LINE)
 		info.setEndPoint(info2, "endToEnd")
-		info.copyToClipboard()
+		if trimmed:
+			api.copyToClip(_trim_lines(info.clipboardText))
+		else:
+			info.copyToClipboard()
 		ui.message("copied")
 
-	def script_copy_to_end(self, gesture):
+	def script_copy_to_end(self, gesture, trimmed=False):
 		info = api.getReviewPosition().copy()
 		info2 = info.copy()
 		info.expand(textInfos.UNIT_LINE)
 		info.setEndPoint(info2, "startToStart")
-		info.copyToClipboard()
+		if trimmed:
+			api.copyToClip(_trim_lines(info.clipboardText))
+		else:
+			info.copyToClipboard()
 		ui.message("copied")
+
+	def script_copy_to_start_trimmed(self, gesture):
+		self.script_copy_to_start(gesture, trimmed=True)
+
+	def script_copy_to_end_trimmed(self, gesture):
+		self.script_copy_to_end(gesture, trimmed=True)
+
+	def _copy_block(self, trimmed=False):
+		pos = api.getReviewPosition().copy()
+		startMarker = getattr(pos.obj, "_copyStartMarker", None)
+		if not startMarker:
+			# Translators: message when no start marker has been set
+			ui.message(_("No start marker"))
+			tones.beep(120, 100)
+			return
+		if startMarker.compareEndPoints(pos, "startToStart") > 0:
+			startMarker, pos = pos, startMarker
+		startMarker.setEndPoint(pos, "endToEnd")
+		t = startMarker.clipboardText
+		if trimmed:
+			t = _trim_lines(t)
+		api.copyToClip(t)
+		tones.beep(700, 100)
+
+	def script_copy_block(self, gesture):
+		self._copy_block(trimmed=False)
+
+	def script_copy_block_trimmed(self, gesture):
+		self._copy_block(trimmed=True)
 
 	def script_virtualCopy(self, gesture):
 		#If already toggling, send it on and clean up

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Allows copying items from the review cursor to the clipboard"""),
 	# version
-	"addon_version" : "1.2.2",
+	"addon_version" : "1.2.3",
 	# Author(s)
 	"addon_author" : u"Tyler Spivey <tspivey@pcdesk.net>",
 	# URL for the add-on documentation support
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2025.1",
+	"addon_lastTestedNVDAVersion": "2026.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
## Summary

- **Trimmed copy:** Shift variants of existing keys (shift+l, shift+k, shift+w, shift+home, shift+end) copy text with leading/trailing whitespace stripped from each line
- **Block copy:** `b` copies from NVDA's start marker (NVDA+F9) to the review cursor; `shift+b` for the trimmed variant
- Bumps addon version to 1.2.3 and last tested NVDA version to 2026.1

## Test plan

- [ ] Build with `scons` and install the `.nvda-addon`
- [ ] Assign a gesture to Virtual Copy in NVDA Input Gestures
- [ ] Verify existing keys (l, k, w, home, end) still work unchanged
- [ ] Verify shift+l/k/w copy trimmed text (whitespace stripped)
- [ ] Verify shift+home/end copy trimmed partial lines
- [ ] Set mark with NVDA+F9, move cursor, press b — should copy the block
- [ ] Press shift+b — should copy the block trimmed
- [ ] Press b without a prior NVDA+F9 mark — should announce "No start marker"