### PR TITLE
Add process_text: strip trailing whitespace from all lines and newlines

### DIFF
--- a/addon/globalPlugins/virtualCopy/__init__.py
+++ b/addon/globalPlugins/virtualCopy/__init__.py
@@ -11,6 +11,10 @@ import addonHandler
 
 addonHandler.initTranslation()
 
+def process_text(text):
+	"""Strip trailing whitespace from every line and trailing newlines from the end."""
+	return '\n'.join(line.rstrip() for line in text.split('\n')).rstrip('\n')
+
 def finally_(func, final):
 	"""Calls final after func, even if it fails."""
 	def wrap(f):
@@ -66,26 +70,25 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def copy_line(self):
 		info = api.getReviewPosition().copy()
 		info.expand(textInfos.UNIT_LINE)
-		info.copyToClipboard()
+		api.copyToClip(process_text(info.clipboardText))
 
 	def copy_word(self):
 		ui.message("word")
 		info = api.getReviewPosition().copy()
 		info.expand(textInfos.UNIT_WORD)
-		info.copyToClipboard()
+		api.copyToClip(process_text(info.clipboardText))
 
 	def copy_window(self):
 		info = api.getReviewPosition().copy()
 		info.expand(textInfos.UNIT_STORY)
-		t = info.clipboardText.rstrip('\n')
-		api.copyToClip(t)
+		api.copyToClip(process_text(info.clipboardText))
 
 	def script_copy_to_start(self, gesture):
 		info = api.getReviewPosition().copy()
 		info2 = info.copy()
 		info.expand(textInfos.UNIT_LINE)
 		info.setEndPoint(info2, "endToEnd")
-		info.copyToClipboard()
+		api.copyToClip(process_text(info.clipboardText))
 		ui.message("copied")
 
 	def script_copy_to_end(self, gesture):
@@ -93,7 +96,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		info2 = info.copy()
 		info.expand(textInfos.UNIT_LINE)
 		info.setEndPoint(info2, "startToStart")
-		info.copyToClipboard()
+		api.copyToClip(process_text(info.clipboardText))
 		ui.message("copied")
 
 	def script_virtualCopy(self, gesture):


### PR DESCRIPTION
## Summary

All copy operations now route through a shared \process_text()\ function instead of calling \info.copyToClipboard()\ directly.

### What process_text does
- Strips trailing whitespace from **every line** (not just the window copy)
- Strips trailing newlines from the end of the result, so copying a line yields \	ext\ not \	ext\n\

### Changes
- Added \process_text(text)\ helper function
- \copy_line\, \copy_word\, \copy_window\, \copy_to_start\, \copy_to_end\ all use it
- Replaced the ad-hoc \strip('\n')\ in \copy_window\ with the shared function